### PR TITLE
Re-enable `noEmitOnError`

### DIFF
--- a/src/deno2node.ts
+++ b/src/deno2node.ts
@@ -9,6 +9,9 @@ function transpileExtension(moduleName: string) {
 const identity = <T>(t: T) => t;
 
 export interface Options {
+  /**
+   * ⚠ Some errors are only reported with `noEmitOnError`!
+   */
   readonly compilerOptions?: ts.CompilerOptions;
   readonly transformModuleSpecifier?: (specifier: string) => string;
   readonly tsConfigFilePath: string;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "declarationMap": true,
     "module": "esnext",
+    "moduleResolution": "node",
     "noEmitOnError": true,
     "outDir": "../lib/",
     "strict": true,

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "declarationMap": true,
     "module": "esnext",
+    "noEmitOnError": true,
     "outDir": "../lib/",
     "strict": true,
     "target": "ES2019"


### PR DESCRIPTION
@dsherret why does build fail (on Deno and Node.js) with `Cannot find module 'ts-morph'` even tho it is installed?

https://github.com/wojpawlik/deno2node/blob/3c9cf71a06a08d4c6db91ae4c4e0aeca40c30164/src/deno2node.ts#L3
Changing to `from "ts-morph"` and `skipLibCheck` don't help. Trying to import something else also fails.