### PR TITLE
Allow `"noEmitOnError": false`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -14,7 +14,6 @@ export class Context {
       compilerOptions: {
         declarationMap: false, // doesn't reflect deno2node transforms
         inlineSourceMap: false, // doesn't reflect deno2node transforms
-        noEmitOnError: true, // for diagnostics
         sourceMap: false, // doesn't reflect deno2node transforms
         strict: true,
       },

--- a/src/emit_and_exit.ts
+++ b/src/emit_and_exit.ts
@@ -1,10 +1,18 @@
-import type { Project } from "./deps.deno.ts";
+import type { Diagnostic, Project, ts } from "./deps.deno.ts";
 
-export function emitAndExit(project: Project): never {
-  const result = project.emitSync();
-  const diagnostics = result.getDiagnostics();
-  if (diagnostics.length === 0) return Deno.exit(0);
+function diagnoze(
+  project: Project,
+  diagnostics: readonly Diagnostic<ts.Diagnostic>[],
+) {
+  if (diagnostics.length === 0) return;
   console.info(project.formatDiagnosticsWithColorAndContext(diagnostics));
   console.info(`Found ${diagnostics.length} errors.`);
   return Deno.exit(1);
+}
+
+export function emitAndExit(project: Project): never {
+  const result = project.emitSync();
+  diagnoze(project, project.getPreEmitDiagnostics());
+  diagnoze(project, result.getDiagnostics());
+  return Deno.exit(0);
 }


### PR DESCRIPTION
@dsherret did I handle diagnostics properly? What are "declaration emit diagnostics", ie. what kinds of errors can they contain? Related: https://github.com/dsherret/ts-morph/issues/384