### PR TITLE
Add npm test script for existing e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "scripts": {
     "fmt": "npm run --silent clean && deno fmt --ignore=node_modules/",
     "lint": "npm run --silent clean && deno lint --ignore=node_modules/",
-    "prepare": "deno run --unstable --allow-read --allow-write='lib/' --allow-env src/cli.ts src/tsconfig.json",
-    "clean": "git clean -fXde '!node_modules/'"
+    "prepare": "npm test",
+    "clean": "git clean -fXde '!node_modules/'",
+    "test": "deno run --unstable --allow-read --allow-write='lib/' --allow-env src/cli.ts src/tsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "fmt": "npm run --silent clean && deno fmt --ignore=node_modules/",
     "lint": "npm run --silent clean && deno lint --ignore=node_modules/",
-    "prepare": "npm test",
-    "clean": "git clean -fXde '!node_modules/'",
-    "test": "deno run --unstable --allow-read --allow-write='lib/' --allow-env src/cli.ts src/tsconfig.json"
+    "test": "npm run --silent prepare",
+    "prepare": "deno run --unstable --allow-read --allow-write='lib/' --allow-env src/cli.ts src/tsconfig.json",
+    "clean": "git clean -fXde !node_modules/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
E2E testing is performed by compiling the tool itself. This is mentioned in the README. However, the intuitive `npm test` does not work.

This PR registers the E2E tests in the `test` script in order to make them available more easily.
