### PR TITLE
Refactor CLI structure for deno install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- deno-fmt-ignore-file -->
+
 # deno2node
 
 Transpiles Deno projects into `.js` and `.d.ts` for Node.js.
@@ -16,17 +17,34 @@ and simplifies development experience:
 
 ## CLI Usage
 
+You can directly run the CLI from the script hosted on `deno.land/x`:
+
 ```sh
-$ deno run \
-  --no-check \
-  --unstable  \
-  --allow-read \
-  --allow-write=<outDir> \
+$ deno run                                 \
+  --no-check                               \
+  --unstable                               \
+  --allow-read                             \
+  --allow-write=<outDir>                   \
   https://deno.land/x/deno2node/src/cli.ts \
   <tsConfigFilePath>
 ```
 
-<!-- deno-fmt-ignore -->
+Alternatively, you can first compile an executable file from it, which can in turn be run:
+
+```sh
+# Install deno2node CLI
+$ deno install                             \
+  --no-check                               \
+  --unstable                               \
+  --allow-read                             \
+  --allow-write                            \
+  --name deno2node
+  https://deno.land/x/deno2node/src/cli.ts \
+  <tsConfigFilePath>
+# Compile your project
+$ deno2node <tsConfigFilePath>
+```
+
 As a by-product of end-to-end testing,
 Node.js build is also available:
 
@@ -101,7 +119,7 @@ Note: vendoring is currently slow and poorly tested.
 Consider recommending [`pnpm`] to users of your library.
 It might be able to deduplicate vendored files across packages.
 
-[`grammY`]: https://github.com/grammyjs/grammY
+[`grammy`]: https://github.com/grammyjs/grammY
 [`pnpm`]: https://github.com/pnpm/pnpm#background
 [`ts-morph`]: https://github.com/dsherret/ts-morph
-[API reference]: https://doc.deno.land/https/deno.land/x/deno2node/src/mod.ts
+[api reference]: https://doc.deno.land/https/deno.land/x/deno2node/src/mod.ts

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ deno install                             \
   --unstable                               \
   --allow-read                             \
   --allow-write                            \
-  --name deno2node
+  --name deno2node                         \
   https://deno.land/x/deno2node/src/cli.ts \
   <tsConfigFilePath>
 # Compile your project

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <!-- deno-fmt-ignore-file -->
-
 # deno2node
 
 Transpiles Deno projects into `.js` and `.d.ts` for Node.js.
@@ -119,7 +118,7 @@ Note: vendoring is currently slow and poorly tested.
 Consider recommending [`pnpm`] to users of your library.
 It might be able to deduplicate vendored files across packages.
 
-[`grammy`]: https://github.com/grammyjs/grammY
+[`grammY`]: https://github.com/grammyjs/grammY
 [`pnpm`]: https://github.com/pnpm/pnpm#background
 [`ts-morph`]: https://github.com/dsherret/ts-morph
-[api reference]: https://doc.deno.land/https/deno.land/x/deno2node/src/mod.ts
+[API reference]: https://doc.deno.land/https/deno.land/x/deno2node/src/mod.ts

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,17 +2,23 @@
 import { ts } from "./deps.deno.ts";
 import { Context, deno2node, emit } from "./mod.ts";
 
-if (Deno.args.length !== 1 || Deno.args[0].startsWith("-")) {
-  console.error("Usage: deno2node <tsConfigFilePath>");
-  Deno.exit(2);
+async function cli(tsConfigFilePath?: string) {
+  const ctx = new Context({ tsConfigFilePath });
+  await deno2node(ctx);
+  const diagnostics = await emit(ctx.project);
+  if (diagnostics.length !== 0) {
+    console.info(ctx.project.formatDiagnosticsWithColorAndContext(diagnostics));
+    console.info("TypeScript", ts.version);
+    console.info(`Found ${diagnostics.length} errors.`);
+    Deno.exit(1);
+  }
 }
 
-const ctx = new Context({ tsConfigFilePath: Deno.args[0] });
-await deno2node(ctx);
-const diagnostics = await emit(ctx.project);
-if (diagnostics.length !== 0) {
-  console.info(ctx.project.formatDiagnosticsWithColorAndContext(diagnostics));
-  console.info("TypeScript", ts.version);
-  console.info(`Found ${diagnostics.length} errors.`);
-  Deno.exit(1);
+if (import.meta.main) {
+  if (Deno.args.length !== 1 || Deno.args[0].startsWith("-")) {
+    console.error("Usage: deno2node <tsConfigFilePath>");
+    Deno.exit(2);
+  }
+  const tsConfigFilePath = Deno.args[0];
+  await cli(tsConfigFilePath);
 }


### PR DESCRIPTION
This PR adds a section to the README file that describes how to install the CLI using `deno install`.

It is [good practice](https://deno.land/manual/tools/script_installer) to check `import.meta.main` in scripts before performing any operations. In order to obey this rule, this PR refactors the CLI structure.